### PR TITLE
almost final version before submitting

### DIFF
--- a/draft-montenegro-httpbis-h2ot.txt
+++ b/draft-montenegro-httpbis-h2ot.txt
@@ -5,12 +5,12 @@
 Network Working Group                                      G. Montenegro
 Internet-Draft                                                 Microsoft
 Intended status: Informational                               S. Cespedes
-Expires: January 5, 2017                            Universidad de Chile
+Expires: January 7, 2017                            Universidad de Chile
                                                                S. Loreto
                                                                 Ericsson
                                                               R. Simpson
                                                         General Electric
-                                                            July 4, 2016
+                                                            July 6, 2016
 
 
                    HTTP/2 for the Internet of Things
@@ -35,7 +35,7 @@ Status of This Memo
    time.  It is inappropriate to use Internet-Drafts as reference
    material or to cite them other than as "work in progress."
 
-   This Internet-Draft will expire on January 5, 2017.
+   This Internet-Draft will expire on January 7, 2017.
 
 Copyright Notice
 
@@ -53,7 +53,7 @@ Copyright Notice
 
 
 
-Montenegro, et al.       Expires January 5, 2017                [Page 1]
+Montenegro, et al.       Expires January 7, 2017                [Page 1]
 
 Internet-Draft               HTTP/2 for IoT                    July 2016
 
@@ -72,61 +72,62 @@ Table of Contents
    3.  Importance of Protocol Reuse  . . . . . . . . . . . . . . . .   7
    4.  HTTP/2 in IoT . . . . . . . . . . . . . . . . . . . . . . . .   9
    5.  Profile of HTTP/2 for IoT . . . . . . . . . . . . . . . . . .  10
-   6.  Negotiation of HTTP/2 for IoT . . . . . . . . . . . . . . . .  10
-   7.  Gateway and Proxying Issues . . . . . . . . . . . . . . . . .  10
-   8.  Implementation Considerations . . . . . . . . . . . . . . . .  11
-   9.  Experimentation and Performance . . . . . . . . . . . . . . .  11
-     9.1.  GET Example . . . . . . . . . . . . . . . . . . . . . . .  12
-       9.1.1.  HTTP/1.1  . . . . . . . . . . . . . . . . . . . . . .  12
-       9.1.2.  HTTP/2  . . . . . . . . . . . . . . . . . . . . . . .  13
+   6.  Negotiation of HTTP/2 for IoT . . . . . . . . . . . . . . . .  11
+   7.  Gateway and Proxying Issues . . . . . . . . . . . . . . . . .  11
+   8.  Implementation Considerations . . . . . . . . . . . . . . . .  12
+   9.  Experimentation and Performance . . . . . . . . . . . . . . .  12
+     9.1.  GET Example . . . . . . . . . . . . . . . . . . . . . . .  13
+       9.1.1.  HTTP/1.1  . . . . . . . . . . . . . . . . . . . . . .  13
+       9.1.2.  HTTP/2  . . . . . . . . . . . . . . . . . . . . . . .  14
        9.1.3.  Comparison  . . . . . . . . . . . . . . . . . . . . .  14
-   10. HTTP/2 over UDP - QUIC  . . . . . . . . . . . . . . . . . . .  14
-   11. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  15
-   12. References  . . . . . . . . . . . . . . . . . . . . . . . . .  15
-     12.1.  Normative References . . . . . . . . . . . . . . . . . .  15
+   10. HTTP/2 over UDP - QUIC  . . . . . . . . . . . . . . . . . . .  15
+   11. Acknowledgements  . . . . . . . . . . . . . . . . . . . . . .  16
+   12. References  . . . . . . . . . . . . . . . . . . . . . . . . .  16
+     12.1.  Normative References . . . . . . . . . . . . . . . . . .  16
      12.2.  Informative References . . . . . . . . . . . . . . . . .  16
-   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  17
+   Authors' Addresses  . . . . . . . . . . . . . . . . . . . . . . .  18
 
 1.  Introduction
 
-   When the IETF started work on IoT with the 6lowpan WG, it was clear
-   that in addition to the lower-layer adaptation work for IPv6, much
-   work elsewhere in the stack was necessary.  (In this document, the
-   "things" in "IoT" are nodes that are constrained in some manner--
-   e.g., cpu, memory, power--such that direct use of unmodified
-   mainstream protocols is challenging.)  Once the IPv6 adaptation was
-   understood, the next question was what protocols to use above IP for
-   different functions and at different layers.  That question may not
+   When the IETF started work on the Internet-of-Things ("IoT") with the
+   6lowpan WG, it was clear that in addition to the lower-layer
+   adaptation work for IPv6, much work elsewhere in the stack was
+   necessary.  (In this document, the "things" in "IoT" are nodes that
+   are constrained in some manner--e.g., cpu, memory, power--such that
+   direct use of unmodified mainstream protocols is challenging.)  Once
+   the IPv6 adaptation was understood, the next question was what
+   protocols to use above IP(v6) for different functions and at
+   different layers to have a complete stack.  That question may not
    have a single answer that is always best for all scenarios and use
    cases.  There are many such use cases, in accordance with the fact
-   that "IoT" means too many things.
+   that IoT means too many things.
 
    Accordingly, the IoT landscape includes a proliferation of options
    for any particular functionality (transport, encoding, security
    suites, authentication/authorization, etc).  Different vendors and
    standards organizations (or fora) offer IoT solutions by grouping
-   these different components into separate stacks.  Even if the
 
 
 
-Montenegro, et al.       Expires January 5, 2017                [Page 2]
+Montenegro, et al.       Expires January 7, 2017                [Page 2]
 
 Internet-Draft               HTTP/2 for IoT                    July 2016
 
 
+   these different components into separate stacks.  Even if the
    components have the same name or originate in the same original
-   standard (or even code base), each organization adapts it ever so
-   slightly to their own goals rendering the resultant components non-
-   interoperable.  Many of these components are being created expressly
-   for IoT (within the IETF and elsewhere) with the justification that
-   the mainstream options could not possibly be usable for IoT
-   scenarios, which results in multiple disparate networking and
+   standard (or even in the same code base), each organization adapts it
+   ever so slightly to their own goals, often rendering the resultant
+   components non-interoperable.  Many of these components are being
+   created expressly for IoT (within the IETF and elsewhere) under the
+   assumption that the mainstream options could not possibly be usable
+   for IoT scenarios.  This results in multiple disparate networking and
    software stacks.  Given the incipient state of IoT, for the
    foreseeable future multiple competing stacks will continue to exist
-   at least in gateways and cloud elements.  This adds complexity to
-   IoT, hence, amplifying the attack surface.  Nevertheless, properly
+   at least in gateways and cloud elements.  The additional complexity
+   to IoT amplifies the attack surface.  Nevertheless, properly
    configured and implemented, mainstream options may not just be
-   workable, but may even be the best option.
+   workable, but may even be the best option at least in some scenarios.
 
    The appearance of one-off stacks (as opposed to a properly configured
    and adapted mainstream stack) is reminiscent of WAP 1.x, a complete
@@ -134,19 +135,20 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
    Internet (albeit from within a walled garden) in the late 90's.  At
    that time the IETF and the W3C started efforts to develop the
    mainstream alternatives.  As a result, today no phone uses WAP.
-   Phone stacks are mainstream TCP/IP protocols (properly configured and
-   adapted, of course).  In contrast, today in IoT we don't just see one
-   non-mainstream stack in IoT, but several (as if we had WAP1, WAP2,
-   WAP3, etc.).  And we may have to live with them for some time, but it
-   is essential to ponder what the mainstream stack might look like if
-   we are to eventually reap the benefits of a true Internet of Things
-   instead of a not-quite-but-kinda-close-to-Internet-non-interoperable-
-   hodge-podge-of-Things.
+   Instead, phone stacks are mainstream TCP/IP protocols (properly
+   configured and adapted, of course).  In contrast, today in IoT we see
+   not just one non-mainstream stack, but several (as if we had not just
+   WAP, but WAP1, WAP2, WAP3, etc.).  And we may have to live with them
+   for some time, but it is essential to ponder what the mainstream
+   stack might look like if we are to eventually reap the benefits of a
+   true Internet of Things instead of a not-quite-but-kinda-close-to-
+   Internet-non-interoperable-hodge-podge-of-Things.
 
-   HTTP/2 is now widely available as a transport option.  Moreover, the
-   ongoing effort to layer HTTP/2 over UDP (i.e., over QUIC) adds a
-   useful capability for IoT scenarios.  We show the current suitability
-   of HTTP/2 for IoT scenarios and examine possible improvements.
+   HTTP/2 [RFC7540][RFC7541] is now widely available as a transport
+   option.  Moreover, the ongoing effort to layer HTTP/2 over UDP (i.e.,
+   over QUIC) adds a useful capability for IoT scenarios.  We show the
+   current suitability of HTTP/2 for IoT scenarios and examine possible
+   improvements.
 
    Let's look at some application communication patterns to establish
    some common language:
@@ -163,9 +165,7 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
 
 
 
-
-
-Montenegro, et al.       Expires January 5, 2017                [Page 3]
+Montenegro, et al.       Expires January 7, 2017                [Page 3]
 
 Internet-Draft               HTTP/2 for IoT                    July 2016
 
@@ -188,8 +188,9 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
       and node to cloud exchanges.
 
    This document makes the case for HTTP/2 as the most general protocol
-   of choice for Internet of Things applications, suitable for both
-   Constrained network scenarios and Internet scenarios.
+   of choice for Internet of Things applications.  HTTP/2 is most at
+   home in Internet scenarios and is also suitable for at least some
+   Constrained network scenarios.
 
 2.  Application Transport Alternatives and their Strengths
 
@@ -209,19 +210,18 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
 
    o  Others: In-house, AMQP and XMPP (43% of developers)
 
-   IT is interesting to note that in the same survey done in 2015,
-   HTTP/2 was not even present, whereas it is now at 19%. No doubt it is
-   being used in scenarios where there are no major constraints
-   (precisely where HTTP/1.x is also being used).  Optimizing it for IoT
-   can further promote its use.  The sections below provide some more
-   details on top-of-the-list protocols other than HTTP/2.
+   It is interesting to note that in the same survey done in 2015,
+   HTTP/2 was not even present, whereas it is now at 19% (the other
+   protocols are mostly unchanged).  No doubt it is being used in
+   scenarios where there are no major constraints (precisely where
+   HTTP/1.x is also being used).  Optimizing it for IoT can further
+   promote its use.  The sections below provide some more details on
+   top-of-the-list protocols other than HTTP/2.
 
 
 
 
-
-
-Montenegro, et al.       Expires January 5, 2017                [Page 4]
+Montenegro, et al.       Expires January 7, 2017                [Page 4]
 
 Internet-Draft               HTTP/2 for IoT                    July 2016
 
@@ -231,16 +231,16 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
    HTTP/1.1 is a text-based protocol, and is widely successful as it is
    the basis not just for the web, but for much non-web traffic in the
    internet today.  Most (but not all) of the instances of HTTP today
-   version 1.1 as specified in RFC2616.  Since its publication back in
-   1999 it has evolved organically, producing countless variations and
-   exceptions to its rules.  Modern browser and server implementations
-   have very complex and convoluted code to deal with parsing and
-   handling the many nuances of the protocol.  Because of all this
-   confusion, the HTTPbis working group set out to clarify the existing
-   specifications, and after a multi-year effort to clarify its many
-   sources of confusion, it has published a cleaner specification in
-   RFCs 7230-7235.  In spite of this, the protocol still has a plethora
-   of legacy issues and remains too verbose.
+   implement version 1.1 as specified in RFC2616 [RFC2616].  Since its
+   publication back in 1999 it has evolved organically, producing
+   countless variations and exceptions to its rules.  Modern browser and
+   server implementations have very complex and convoluted code to deal
+   with parsing and handling the many nuances of the protocol.  Because
+   of all this confusion, the HTTPbis working group set out to clarify
+   the existing specifications, and after a multi-year effort to clarify
+   its many sources of confusion, it has published a cleaner
+   specification in RFCs 7230-7235.  In spite of this, the protocol
+   still has a plethora of legacy issues and remains too verbose.
 
    HTTP/1.1 is very clearly a mismatch for the constrained devices and
    networks that characterize IoT.  Despite its shortcomings, it is the
@@ -277,7 +277,7 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
 
 
 
-Montenegro, et al.       Expires January 5, 2017                [Page 5]
+Montenegro, et al.       Expires January 7, 2017                [Page 5]
 
 Internet-Draft               HTTP/2 for IoT                    July 2016
 
@@ -296,47 +296,57 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
    be used in constrained devices and constrained networks.  The
    protocol specification has been published in RFC 7252, although
    additional functionalities such as congestion control, block-wise
-   transfer, TCP transfer and HTTP mapping are still being specified.
+   transfer, TCP and TLS transfer and HTTP mapping are still being
+   specified.
 
    The protocol meets IoT requirements through the modification of some
    HTTP functionalities to achieve low-power consumption and operation
    over lossy links.  To avoid undesirable packet fragmentation the CoAP
-   specification provides also an upper bound to the message size,
-   dictating that a CoAP message, appropriately encapsulated, SHOULD fit
-   within a single IP datagram
+   specification provides an upper bound to the message size, dictating
+   that a CoAP message, appropriately encapsulated, SHOULD fit within a
+   single IP datagram
 
       If the Path MTU is not known for a destination, an IP MTU of 1280
       bytes SHOULD be assumed; if nothing is known about the size of the
       headers, good upper bounds are 1152 bytes for the message size and
       1024 bytes for the payload size.
 
-   In addition, CoAP may interact easily with HTTP through a proxy
-   thanks to the common REST architecture.  CoAP works on port 5683 and
-   offers optional reliable delivery (thru a retransmission mechanism),
-   support for unicast and multicast (which satisfies group
-   communication for IoT), and asynchronous message exchange using
-   simple and low complexity headers (a typical CoAP message can be
-   between 10 and 20 bytes).
+   CoAP interaction with HTTP must traverse a proxy, but at least the
+   common REST architecture makes it easier.  CoAP works on port 5683
+   and offers optional reliable delivery (thru a retransmission
+   mechanism), support for unicast and multicast, and asynchronous
+   message exchange.  Multicast is touted as required to support group
+   communications.  In practice, it is used by IoT SDO's for discovery
+   which is addressed in mainstream (and even some IoT) scenarios via
+   mDNS [RFC6762] and DNS-SD [RFC6763].  More general uses of multicast
+   at the application transport, e.g., to address group communication
+   for IoT, introduces complexity for security, IPv6 scoping, wireless
+   reliability, etc.
+
+   A typical CoAP message can be between 10 and 20 bytes.
 
    It is the third most popular protocol in the survey with a 21%
    preference.  Nevertheless, since CoAP is UDP-based, it also suffers
    from firewall traversal issues, verbosity (as compared to TCP) to
    maintain state in NAT boxes and lack of integration with existing
    enterprise infrastructures.  There is ongoing work to specify the use
-   of CoAP over TCP as well as CoAP over TLS, in an attempt to overcome
-   issues with middleboxes and achieve a better integration with web
-   environments.
 
 
 
-
-
-
-
-Montenegro, et al.       Expires January 5, 2017                [Page 6]
+Montenegro, et al.       Expires January 7, 2017                [Page 6]
 
 Internet-Draft               HTTP/2 for IoT                    July 2016
 
+
+   of CoAP over TCP as well as CoAP over TLS, in an attempt to overcome
+   issues with middleboxes and improve its applicability to Internet
+   scenarios.
+
+   As noted above, there is much ongoing work on CoAP, and much of it
+   seeks to define a transport on top of UDP.  This is a very complex
+   task not to be underestimated.  QUIC is also embarking on this task,
+   but it is a mainstream effort and consequently benefits from many
+   more resources by the networking community at large.
 
 2.4.  Protocols Comparison
 
@@ -366,7 +376,7 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
    CoAP configuration resulted to be lower even when the number of
    concurrent requests increases [CoAP_integration].
 
-   No reports have been found comparing MQTT or CoAP to HTTP/2.
+   To date, no reports have been found comparing MQTT or CoAP to HTTP/2.
 
 3.  Importance of Protocol Reuse
 
@@ -376,6 +386,14 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
    these multiple IoT protocols (and stacks) provide very useful sources
    of information for prying eyes (See "US intelligence chief says we
    might use the IoT to spy on you" at http://www.wired.com/2012/03/
+
+
+
+Montenegro, et al.       Expires January 7, 2017                [Page 7]
+
+Internet-Draft               HTTP/2 for IoT                    July 2016
+
+
    petraeus-tv-remote/).  Security and privacy issues are exacerbated
    because:
 
@@ -386,13 +404,6 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
 
    o  Each of these protocols is an island with its own security
       measures (or lack thereof) and very limited review.
-
-
-
-Montenegro, et al.       Expires January 5, 2017                [Page 7]
-
-Internet-Draft               HTTP/2 for IoT                    July 2016
-
 
    The previous two points can be summarized as follows:
 
@@ -432,6 +443,13 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
    as Shodan (https://www.shodan.io/), but also represents a great
    opportunity for government agencies' surveillance needs [Going_Dark].
 
+
+
+Montenegro, et al.       Expires January 7, 2017                [Page 8]
+
+Internet-Draft               HTTP/2 for IoT                    July 2016
+
+
    Reusing mainstream protocols affords the benefits of using better-
    known technology, with easier access to reference implementations
    (including open source), hiring of people with the required skills
@@ -441,14 +459,6 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
    for the most part it was applied to only a limited set of components
    (e.g., IP, UDP, DTLS).  Other components are still being custom built
    (albeit, on top of IP).
-
-
-
-
-Montenegro, et al.       Expires January 5, 2017                [Page 8]
-
-Internet-Draft               HTTP/2 for IoT                    July 2016
-
 
 4.  HTTP/2 in IoT
 
@@ -472,12 +482,15 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
    must be properly profiled and optimized.  This requires optimizing
    aspects such as:
 
-   o  Authentication and Authorization framework via OAUTH
+   o  Authentication and Authorization framework by adapting OAUTH
+      instead of inventing a new system [I-D.ietf-ace-oauth-authz]
 
    o  Device Management and Object Model/Descriptions (currently being
       defined)
 
-   o  Discovery via mDNS/DNS-SD
+   o  Discovery via mDNS [RFC6762] and DNS-SD [RFC6763] perhaps
+      augmented with IoT considerations, e.g.,
+      [I-D.aggarwal-dnssd-optimize-query]
 
    o  Application Transport based on HTTP/2
 
@@ -486,25 +499,22 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
 
    HTTP/2 is a good match for IoT for several reasons:
 
+
+
+Montenegro, et al.       Expires January 7, 2017                [Page 9]
+
+Internet-Draft               HTTP/2 for IoT                    July 2016
+
+
    o  Binary and Compact (9 byte header)
 
-   o  Header Compression
+   o  Header Compression [RFC7541]
 
    o  Traversal past firewalls/middle boxes via TLS over port 443
 
    o  Support of RESTful model in major development frameworks
 
    o  Know-how widely available
-
-
-
-
-
-
-Montenegro, et al.       Expires January 5, 2017                [Page 9]
-
-Internet-Draft               HTTP/2 for IoT                    July 2016
-
 
 5.  Profile of HTTP/2 for IoT
 
@@ -513,33 +523,70 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
    requirements.  Specifically, the following settings and values have
    been found to be useful in IoT applications:
 
-   o  SETTINGS_ENABLE_PUSH: This setting allows to enable/disable server
-      push.  This functionality may not be required in some IoT
-      applications
-
    o  SETTINGS_HEADER_TABLE_SIZE: this setting allows hosts to limit the
       size of the header compression table used for decoding, reducing
-      required RAM, but potentially increasing bandwidth requirements
+      required RAM, but potentially increasing bandwidth requirements.
+      Initial value per HTTP/2 is 4096.  IoT scenarios might benefit
+      from changing this to a smaller value (e.g., 512), however, to
+      avoid increased bandwidth usage, IoT scenarios should judiciously
+      use HTTP headers and the dynamic header table [RFC7541].
+
+   o  SETTINGS_ENABLE_PUSH: This setting allows to enable/disable server
+      push.  This functionality may not be required in some IoT
+      applications.  The initial value per HTTP/2 is 1.
+
+   o  SETTINGS_MAX_CONCURRENT_STREAMS: this setting allows a sender to
+      limit the number of simultaneous streams that a receiver can
+      create for a connection.  HTTP/2 recommends this value be no
+      smaller than 100.  IoS scenarios may wish to limit this to a much
+      smaller number, such as 2 or 3.
 
    o  SETTINGS_INITIAL_WINDOW_SIZE: this setting allows hosts to limit
       the flow control window, potentially reducing buffer requirements
       at the expense of potentially underutilized bandwidth-delay
-      products
-
-   o  SETTINGS_MAX_CONCURRENT_STREAMS: this settings allows hosts to
-      limit the number of simultaneous streams for a connection
+      products.  Per HTTP/2 the initial value is 2^16-1 (65,535) octets.
+      IoT scenarios may wish to limit this to smaller values in
+      accordance with the node's constraints (e.g., a few kilo-octets).
 
    o  SETTINGS_MAX_FRAME_SIZE: this setting allows hosts to specify the
-      largest frame size they are willing to receive.  Somewhat
+      largest frame size they are willing to receive.  Per HTTP/2 the
+      initial value is 2^14 (16,384) octets.  Somewhat
       counterintuitively, IoT hosts may wish to leave this value large
       and rely on flow control to avoid unnecessary framing overhead.
 
+
+
+
+Montenegro, et al.       Expires January 7, 2017               [Page 10]
+
+Internet-Draft               HTTP/2 for IoT                    July 2016
+
+
    o  SETTINGS_MAX_HEADER_LIST_SIZE: this setting allows hosts to limit
-      the maximum size of the header list they are willing to receive
+      the maximum size of the header list they are willing to receive.
+      Per HTTP/2 the initial value of this setting is unlimited.  IoT
+      scenarios may wish to limit this to smaller values in accordance
+      with the node's constraints (e.g., a few kilo-octets).
 
 6.  Negotiation of HTTP/2 for IoT
 
-   TODO
+   For Internet scenarios, it is assumed that HTTP/2 runs over TLS.
+   Accordingly, the ALPN negotiation in section 3.3 of [RFC7540]
+   applies.  As seen above, an IoT scenario may wish to depart from the
+   default SETTINGS.  To do so, the usual SETTINGS negotiation applies.
+   In this case, the initial SETTINGS negotiation setup is based on the
+   first message exchange initiated by the client.  This is simpler than
+   general HTTP/2 case: not having an in-the-clear Upgrade path means
+   the client is always in control of first HTTP/2 message, including
+   any SETTINGS changes it may wish.
+
+   Additionally, the use of "prior knowledge" per section 3.4 of
+   [RFC7540] is likely to also work particularly well in IoT scenarios
+   in which a client and its web service are likely to be closely
+   matched.  In such scenarios, prior knowledge may allow for SETTINGS
+   to be set in accordance with some shared state implied by the the
+   prior knowledge.  In such cases, SETTINGS negotiation may not be
+   necessary in order to depart from the defaults as defined by HTTP/2.
 
 7.  Gateway and Proxying Issues
 
@@ -554,14 +601,6 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
    In such cases, communication is facilitated by a cross-protocol proxy
    or a gateway translating from one protocol syntax and semantic into
    another one.  However, the presence of Cross-Protocol or Application
-
-
-
-Montenegro, et al.       Expires January 5, 2017               [Page 10]
-
-Internet-Draft               HTTP/2 for IoT                    July 2016
-
-
    gateways has at least two main drawbacks that need to be analyzed and
    addressed carefully.
 
@@ -569,6 +608,15 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
       there are a lot of cases where the translation can lead to
       information loss or an incompatibility due to the different way
       different proxies make the translation.
+
+
+
+
+
+Montenegro, et al.       Expires January 7, 2017               [Page 11]
+
+Internet-Draft               HTTP/2 for IoT                    July 2016
+
 
    o  The presence of such devices may also become a critical point for
       security.
@@ -611,13 +659,6 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
    The results presented in this section make the following assumptions
    and considerations:
 
-
-
-Montenegro, et al.       Expires January 5, 2017               [Page 11]
-
-Internet-Draft               HTTP/2 for IoT                    July 2016
-
-
    o  Overhead from TCP and TLS are ignored
 
    o  An attempt to minimize the headers used has been made while still
@@ -625,6 +666,13 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
 
    o  No entries are made into the HTTP/2 dynamic table, thus removing
       some potential optimization
+
+
+
+Montenegro, et al.       Expires January 7, 2017               [Page 12]
+
+Internet-Draft               HTTP/2 for IoT                    July 2016
+
 
    o  Connection establishment and teardown have been ignored, though
       clearly these are important considerations for IoT application
@@ -664,16 +712,6 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
 
        In ASCII:
 
-
-
-
-
-
-Montenegro, et al.       Expires January 5, 2017               [Page 12]
-
-Internet-Draft               HTTP/2 for IoT                    July 2016
-
-
    HTTP/1.1 200 OK\r\n
    Date: Mon, 09 Mar 2015 06:26:44 GMT\r\n
    Content-Length: 36\r\n
@@ -682,6 +720,15 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
    <OnOff>\n
    \t<state>off</state>\n
    </OnOff>
+
+
+
+
+
+Montenegro, et al.       Expires January 7, 2017               [Page 13]
+
+Internet-Draft               HTTP/2 for IoT                    July 2016
+
 
 9.1.2.  HTTP/2
 
@@ -721,15 +768,6 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
 
        Representing:
 
-
-
-
-
-Montenegro, et al.       Expires January 5, 2017               [Page 13]
-
-Internet-Draft               HTTP/2 for IoT                    July 2016
-
-
    <OnOff>
    \t<state>off</state>
    </OnOff>
@@ -738,6 +776,15 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
 
    In total and ignoring the payload (36 octets), the HTTP/2 flow is 37%
    smaller than the HTTP/1.1 flow.
+
+
+
+
+
+Montenegro, et al.       Expires January 7, 2017               [Page 14]
+
+Internet-Draft               HTTP/2 for IoT                    July 2016
+
 
    The use of additional headers, particularly common headers that are
    present in the HTTP/2 static table, will result in greater savings.
@@ -750,27 +797,27 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
 
    QUIC (Quick UDP Internet Connections) is a new multiplexed transport
    protocol designed to run in user space above UDP, optimized for
-   HTTP/2 semantics.  The protocol is still in its early days and the
+   HTTP/2 semantics.  In this document, "QUIC" refers to the upcoming
+   IETF standard.  The protocol is still in its early days and the
    standardization work in IETF has just started.
 
-   QUIC provides functionality already present in TCP, TLS and HTTP/2
+   QUIC provides functionality already present in TCP and HTTP/2
 
    o  connection semantics, reliability, and congestion control
       equivalent to TCP.
 
-   o  security equivalent to TLS
-
    o  multiplexing and flow control equivalent to HTTP/2
 
    Where functionality is similar to that of existing protocols, it has
-   been re-designed to be more efficient.
+   been re-designed to be more efficient.  For example, the native
+   multistream provides multiplexing without the head-of-line blocking
+   inherent to HTTP/2 over TCP.
 
-   To improve connection establishment latency QUIC combines the crypto
-   and transport handshakes, reducing the number of roundtrips required
-   to set up a secure connection.  QUIC connections are commonly 0-RTT,
-   meaning that on most QUIC connections, data can be sent immediately
-   without waiting for a reply from the server, as compared to the 1-3
-   roundtrips required for TCP+TLS before application data can be sent.
+   QUIC will use TLS 1.3.  Accordingly, connections will commonly
+   benefit from 0-RTT as defined by TLS 1.3, meaning that on most QUIC
+   connections, data can be sent immediately without waiting for a reply
+   from the server.  Furthermore, packets are always authenticated and
+   typically the payload is fully encrypted.
 
    QUIC has been designed to provide richer information to congestion
    control algorithms than TCP, moreover the actual congestion control
@@ -778,14 +825,6 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
 
    Even if QUIC has been initially designed with HTTP/2 as the primary
    application protocol to support, it is meant to become a modern
-
-
-
-Montenegro, et al.       Expires January 5, 2017               [Page 14]
-
-Internet-Draft               HTTP/2 for IoT                    July 2016
-
-
    general-purpose transport protocol.  The IETF standardization effort
    will also focus on describing the mapping of HTTP/2 semantics using
    QUIC specifically with the goal of minimizing web latency using QUIC.
@@ -794,19 +833,23 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
 
    QUIC also dictates that packets should be sized to fit within the
    path's MTU to avoid IP fragmentation.  However path MTU discovery is
+
+
+
+
+Montenegro, et al.       Expires January 7, 2017               [Page 15]
+
+Internet-Draft               HTTP/2 for IoT                    July 2016
+
+
    work in progress, and the current QUIC implementation uses a
    1350-byte maximum QUIC packet size for IPv6, 1370 for IPv4.
 
-   QUIC will improve the HTTP/2 match for IoT described in the previous
-   section as With QUIC:
-
-   o  packets are always authenticated and typically the payload is
-      fully encrypted
-
-   o  connections are commonly 0-RTT
-
-   o  the native multistream provides multiplexing without head-of-line
-      blocking
+   Judging from its current state, QUIC may bring some potential
+   benefits like the possibility to design and use a specific congestion
+   control algorithm suited to IoT scenarios and possibility to reduce
+   header overhead as compared to that of TCP plus HTTP/2.  The latter
+   is possible since these two layers are more integrated in QUIC.
 
 11.  Acknowledgements
 
@@ -821,44 +864,71 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
               DOI 10.17487/RFC2119, March 1997,
               <http://www.rfc-editor.org/info/rfc2119>.
 
-   [RFC2616]  Fielding, R., Gettys, J., Mogul, J., Frystyk, H.,
-              Masinter, L., Leach, P., and T. Berners-Lee, "Hypertext
-              Transfer Protocol -- HTTP/1.1", RFC 2616,
-              DOI 10.17487/RFC2616, June 1999,
-              <http://www.rfc-editor.org/info/rfc2616>.
-
    [RFC7230]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
               Protocol (HTTP/1.1): Message Syntax and Routing",
               RFC 7230, DOI 10.17487/RFC7230, June 2014,
               <http://www.rfc-editor.org/info/rfc7230>.
-
-
-
-
-
-
-Montenegro, et al.       Expires January 5, 2017               [Page 15]
-
-Internet-Draft               HTTP/2 for IoT                    July 2016
-
 
    [RFC7231]  Fielding, R., Ed. and J. Reschke, Ed., "Hypertext Transfer
               Protocol (HTTP/1.1): Semantics and Content", RFC 7231,
               DOI 10.17487/RFC7231, June 2014,
               <http://www.rfc-editor.org/info/rfc7231>.
 
+   [RFC7540]  Belshe, M., Peon, R., and M. Thomson, Ed., "Hypertext
+              Transfer Protocol Version 2 (HTTP/2)", RFC 7540,
+              DOI 10.17487/RFC7540, May 2015,
+              <http://www.rfc-editor.org/info/rfc7540>.
+
+   [RFC7541]  Peon, R. and H. Ruellan, "HPACK: Header Compression for
+              HTTP/2", RFC 7541, DOI 10.17487/RFC7541, May 2015,
+              <http://www.rfc-editor.org/info/rfc7541>.
+
 12.2.  Informative References
+
+   [I-D.ietf-ace-oauth-authz]
+              Seitz, L., Selander, G., Wahlstroem, E., Erdtman, S., and
+              H. Tschofenig, "Authentication and Authorization for
+              Constrained Environments (ACE)", draft-ietf-ace-oauth-
+              authz-02 (work in progress), June 2016.
+
+
+
+Montenegro, et al.       Expires January 7, 2017               [Page 16]
+
+Internet-Draft               HTTP/2 for IoT                    July 2016
+
+
+   [I-D.aggarwal-dnssd-optimize-query]
+              Aggarwal, A., "Optimizing DNS-SD query using TXT records",
+              draft-aggarwal-dnssd-optimize-query-00 (work in progress),
+              July 2014.
+
+   [RFC2616]  Fielding, R., Gettys, J., Mogul, J., Frystyk, H.,
+              Masinter, L., Leach, P., and T. Berners-Lee, "Hypertext
+              Transfer Protocol -- HTTP/1.1", RFC 2616,
+              DOI 10.17487/RFC2616, June 1999,
+              <http://www.rfc-editor.org/info/rfc2616>.
 
    [RFC2629]  Rose, M., "Writing I-Ds and RFCs using XML", RFC 2629,
               DOI 10.17487/RFC2629, June 1999,
               <http://www.rfc-editor.org/info/rfc2629>.
+
+   [RFC6762]  Cheshire, S. and M. Krochmal, "Multicast DNS", RFC 6762,
+              DOI 10.17487/RFC6762, February 2013,
+              <http://www.rfc-editor.org/info/rfc6762>.
+
+   [RFC6763]  Cheshire, S. and M. Krochmal, "DNS-Based Service
+              Discovery", RFC 6763, DOI 10.17487/RFC6763, February 2013,
+              <http://www.rfc-editor.org/info/rfc6763>.
 
    [Deuterium]
               Simpson, R., "Deuterium HTTP/2 Library", June 2016,
               <http://robbysimpson.org/deuterium/>.
 
    [Eclipse_survey]
-              Eclipse Foundation, "IoT Developer Survey", April 2016.
+              Eclipse Foundation, "IoT Developer Survey", April 2016,
+              <http://iot.ieee.org/images/files/pdf/
+              iot-developer-survey-2016-report-final.pdf>.
 
    [IEEE_survey]
               Al-Fuqaha, A., Guizani, M., Mohammadi, M., Aledhari, M.,
@@ -871,6 +941,18 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
               C. Niedermier, "Connecting the web with the web of things:
               lessons learned from implementing a CoAP-HTTP proxy",
               Proc. IEEE MASS , 2012.
+
+
+
+
+
+
+
+
+Montenegro, et al.       Expires January 7, 2017               [Page 17]
+
+Internet-Draft               HTTP/2 for IoT                    July 2016
+
 
    [IoT_analysis]
               Colina, M., Bartolucci, M., Vanelli-Coralli, A., and G.
@@ -888,15 +970,6 @@ Internet-Draft               HTTP/2 for IoT                    July 2016
               February 2016, <https://cyber.law.harvard.edu/pubrelease/
               dont-panic/
               Dont_Panic_Making_Progress_on_Going_Dark_Debate.pdf>.
-
-
-
-
-
-Montenegro, et al.       Expires January 5, 2017               [Page 16]
-
-Internet-Draft               HTTP/2 for IoT                    July 2016
-
 
    [Clapper]  "US intelligence chief: we might use the internet of
               things to spy on you", February 2016,
@@ -932,21 +1005,4 @@ Authors' Addresses
 
 
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-Montenegro, et al.       Expires January 5, 2017               [Page 17]
+Montenegro, et al.       Expires January 7, 2017               [Page 18]

--- a/draft-montenegro-httpbis-h2ot.xml
+++ b/draft-montenegro-httpbis-h2ot.xml
@@ -553,25 +553,27 @@ date: Mon, 09 Mar 2015 06:26:44 GMT
 
 <section title="HTTP/2 over UDP - QUIC"> 
   <t>
-    QUIC (Quick UDP Internet Connections) is a new multiplexed transport protocol designed to run in user space above UDP, optimized for HTTP/2 semantics. The protocol
+    QUIC (Quick UDP Internet Connections) is a new multiplexed transport protocol designed to run in user space above UDP, optimized for HTTP/2 semantics. In this document, "QUIC" refers to the upcoming IETF standard. The protocol
     is still in its early days and the standardization work in IETF has just started.</t>
 
-  <t>QUIC provides functionality already present in TCP, TLS and HTTP/2
+  <t>QUIC provides functionality already present in TCP and HTTP/2
 
   <list style='symbols'>
 		<t> connection semantics, reliability, and congestion control equivalent to TCP.</t>
-		<t> security equivalent to TLS </t>
 		<t> multiplexing and flow control equivalent to HTTP/2</t>
 	</list>
-
    </t>
 
-   <t>Where functionality is similar to that of existing protocols, it has been re-designed to be more efficient.</t>
+   <t>
+   Where functionality is similar to that of existing protocols, it has been re-designed to be more efficient.
+   For example, the native multistream provides multiplexing without the head-of-line blocking inherent to HTTP/2 over TCP.
+   </t>
 
-   <t>To improve connection establishment latency QUIC combines the crypto and transport handshakes, reducing the
-   number of roundtrips required to set up a secure connection. QUIC connections are commonly 0-RTT, meaning that on most QUIC
-   connections, data can be sent immediately without waiting for a reply from the server, as compared to the 1-3 roundtrips required for
-   TCP+TLS before application data can be sent.</t>
+   <t>
+    QUIC will use TLS 1.3. Accordingly, connections will commonly benefit from 0-RTT as defined by TLS 1.3, 
+    meaning that on most QUIC connections, data can be sent immediately without waiting for a reply from the server.
+    Furthermore, packets are always authenticated and typically the payload is fully encrypted.
+   </t>
 
    <t>QUIC has been designed to provide richer information to congestion control algorithms than TCP, moreover the actual congestion control
    is plugable in QUIC.</t> 
@@ -582,15 +584,6 @@ date: Mon, 09 Mar 2015 06:26:44 GMT
 
    <t>QUIC also dictates that packets should be sized to fit within the path's MTU to avoid IP fragmentation. However path MTU discovery is work in
    progress, and the current QUIC implementation uses a 1350-byte maximum QUIC packet size for IPv6, 1370 for IPv4.</t>
-
-<t>
-  QUIC will improve the HTTP/2 match for IoT described in the previous section as With QUIC:
-    <list style='symbols'>
-		<t>packets are always authenticated and typically the payload is fully encrypted</t>
-		<t>connections are commonly 0-RTT</t>
-                <t>the native multistream provides multiplexing without head-of-line blocking</t>
-  	</list>
-</t>
 
 </section>
 

--- a/draft-montenegro-httpbis-h2ot.xml
+++ b/draft-montenegro-httpbis-h2ot.xml
@@ -14,6 +14,8 @@
   <!ENTITY RFC5246 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.5246.xml'>
   <!ENTITY RFC6454 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.6454.xml'>
   <!ENTITY RFC6455 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.6455.xml'>
+  <!ENTITY RFC6762 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.6762.xml'>
+  <!ENTITY RFC6763 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.6763.xml'>
   <!ENTITY RFC7230 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.7230.xml'>
   <!ENTITY RFC7231 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.7231.xml'>
   <!ENTITY RFC7540 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.7540.xml'>
@@ -258,8 +260,13 @@ resource constrained devices and unreliable networks.
  
       CoAP interaction with HTTP must traverse a proxy, but at least the common REST architecture makes it easier. 
       CoAP works on port 5683 and offers optional reliable 
-      delivery (thru a retransmission mechanism), support for unicast and multicast (which attempts to address group communication for IoT, but also 
-      introduces complexity for security, IPv6 scoping, wireless reliability, etc), and asynchronous message exchange.
+      delivery (thru a retransmission mechanism), support for unicast and multicast, and asynchronous message exchange.
+      Multicast is touted as required to support group communications. In practice, it is used by IoT SDO's for discovery 
+      which is addressed in mainstream (and even some IoT) scenarios via mDNS <xref target="RFC6762"/> and DNS-SD <xref target="RFC6763"/>. 
+      More general uses of multicast at the application transport, e.g., to address group communication for IoT, 
+      introduces complexity for security, IPv6 scoping, wireless reliability, etc. 
+      </t>
+      <t>
       A typical CoAP message can be between 10 and 20 bytes. 
       </t>
       <t>
@@ -352,9 +359,11 @@ The goals in pursuing a canonical stack are the following:
 To arrive at a canonical stack the mainstream standards-based stack must be properly profiled and optimized. This
 requires optimizing aspects such as:
   <list style='symbols'>
-		<t>Authentication and Authorization framework via OAUTH</t>
+		<t>Authentication and Authorization framework by adapting OAUTH instead of inventing a new system 
+      <xref target="I-D.ietf-ace-oauth-authz" /> </t>
 		<t>Device Management and Object Model/Descriptions (currently being defined)</t>
-		<t>Discovery via mDNS/DNS-SD</t>
+		<t>Discovery via mDNS <xref target="RFC6762"/> and DNS-SD <xref target="RFC6763"/> perhaps augmented with IoT considerations, e.g., 
+        <xref target="I-D.aggarwal-dnssd-optimize-query" /> </t>
     <t>Application Transport based on HTTP/2</t>
 	</list>
   This document deals only with the application layer transport based on HTTP/2. 
@@ -624,9 +633,18 @@ date: Mon, 09 Mar 2015 06:26:44 GMT
    </references>
 
    <references title="Informative References">
+
+      <?rfc include="reference.I-D.ietf-ace-oauth-authz.xml"?>
+      
+      <?rfc include="reference.I-D.aggarwal-dnssd-optimize-query.xml"?>
+     
       &RFC2616;
       
       &RFC2629;
+
+      &RFC6762;
+
+      &RFC6763;
       
       <reference anchor="Deuterium" target="http://robbysimpson.org/deuterium/">
         <front>

--- a/draft-montenegro-httpbis-h2ot.xml
+++ b/draft-montenegro-httpbis-h2ot.xml
@@ -16,7 +16,9 @@
   <!ENTITY RFC6455 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.6455.xml'>
   <!ENTITY RFC7230 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.7230.xml'>
   <!ENTITY RFC7231 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.7231.xml'>
-  ]>
+  <!ENTITY RFC7540 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.7540.xml'>
+  <!ENTITY RFC7541 PUBLIC '' 'http://xml.resource.org/public/rfc/bibxml/reference.RFC.7541.xml'>
+]>
 
 <?xml-stylesheet type="text/xsl" href="rfc2629.xml"?>
 
@@ -105,7 +107,7 @@ This document makes the case for HTTP/2 for IoT.
     a true Internet of Things instead of a not-quite-but-kinda-close-to-Internet-non-interoperable-hodge-podge-of-Things.
 </t>
 <t> 
-    HTTP/2 is now widely available as a transport option. Moreover, the ongoing effort to layer HTTP/2 
+    HTTP/2 <xref target="RFC7540"/><xref target="RFC7541"/> is now widely available as a transport option. Moreover, the ongoing effort to layer HTTP/2 
     over UDP (i.e., over QUIC) adds a useful capability for IoT scenarios. We show the current suitability of 
     HTTP/2 for IoT scenarios and examine possible improvements.    
     </t>
@@ -159,7 +161,7 @@ This document makes the case for HTTP/2 for IoT.
 <section title="Application Transport Alternatives and their Strengths"> 
   <t>
 		A recent survey by the Eclipse IoT working group queried IoT developers about the protocols and technologies they are using 
-    and planning to use <xref target="Eclipse_survey"></xref>. Some of the currently used application transport protocols 
+    and planning to use <xref target="Eclipse_survey" />. Some of the currently used application transport protocols 
     (above the link layer) for IoT applications are as follows:
     
   <list style='symbols'>
@@ -183,7 +185,7 @@ This document makes the case for HTTP/2 for IoT.
 	</t>
   
   <t>
-    IT is interesting to note that in the same survey done in 2015, HTTP/2 was not even present, whereas it is now at 19% (the other protocols
+    It is interesting to note that in the same survey done in 2015, HTTP/2 was not even present, whereas it is now at 19% (the other protocols
     are mostly unchanged). No doubt
     it is being used in scenarios where there are no major constraints (precisely where HTTP/1.x is also being used). Optimizing it for IoT
     can further promote its use. The sections below provide some more details on top-of-the-list protocols other than HTTP/2.
@@ -192,7 +194,7 @@ This document makes the case for HTTP/2 for IoT.
     <section title="HTTP/1.1"> 
 		<t> 
       HTTP/1.1 is a text-based protocol, and is widely successful as it is the basis not just for the web, but for much non-web traffic in the internet today.
-      Most (but not all) of the instances of HTTP today version 1.1 as specified in RFC2616. Since its publication back in 1999 it has evolved organically,
+      Most (but not all) of the instances of HTTP today implement version 1.1 as specified in RFC2616 <xref target="RFC2616"/>. Since its publication back in 1999 it has evolved organically,
       producing countless variations and exceptions to its rules. Modern browser and server implementations have very complex and convoluted
       code to deal with parsing and handling the many nuances of the protocol. Because of all this confusion, the HTTPbis working group set out to
       clarify the existing specifications, and after a multi-year effort to clarify its many sources of confusion, it has published a cleaner specification
@@ -238,7 +240,7 @@ resource constrained devices and unreliable networks.
       CoAP is a compact, binary UDP-based protocol based on RESTful principles and closely patterned after HTTP. 
       It has been designed to be used in constrained devices and constrained networks. 
       The protocol specification has been published in RFC 7252, although additional functionalities such as congestion control, 
-      block-wise transfer, TCP transfer and HTTP mapping are still being specified. 
+      block-wise transfer, TCP and TLS transfer and HTTP mapping are still being specified. 
       </t>
 
 
@@ -253,19 +255,21 @@ resource constrained devices and unreliable networks.
                   headers, good upper bounds are 1152 bytes for the message size and 1024 bytes for the payload size. 
 		</t>
       </list>
-   
-
  
       CoAP interaction with HTTP must traverse a proxy, but at least the common REST architecture makes it easier. 
       CoAP works on port 5683 and offers optional reliable 
       delivery (thru a retransmission mechanism), support for unicast and multicast (which attempts to address group communication for IoT, but also 
-      introduces complexity for security, IPv6 scoping, wireless reliability, etc), and asynchronous message exchange 
+      introduces complexity for security, IPv6 scoping, wireless reliability, etc), and asynchronous message exchange.
       A typical CoAP message can be between 10 and 20 bytes. 
       </t>
       <t>
       It is the third most popular protocol in the survey with a 21% preference. Nevertheless, since CoAP is UDP-based, it also suffers from firewall traversal issues, verbosity (as compared to TCP) to maintain state in NAT boxes and lack of integration with existing enterprise infrastructures. There is ongoing work to specify the use of CoAP over TCP as well as CoAP over TLS, in an attempt to overcome issues with middleboxes and improve its applicability to Internet scenarios.
 		</t>
-
+    <t>
+      As noted above, there is much ongoing work on CoAP, and much of it seeks to define a transport on top of UDP. This is a very complex
+      task not to be underestimated. QUIC is also embarking on this task, but it is a mainstream effort and consequently
+      benefits from many more resources by the networking community at large. 
+    </t> 
     </section>
     
  <section title="Protocols Comparison"> 
@@ -359,7 +363,7 @@ requires optimizing aspects such as:
   HTTP/2 is a good match for IoT for several reasons:
     <list style='symbols'>
 		<t>Binary and Compact (9 byte header)</t>
-		<t>Header Compression</t>
+		<t>Header Compression <xref target="RFC7541"/></t>
 		<t>Traversal past firewalls/middle boxes via TLS over port 443 </t>
     <t>Support of RESTful model in major development frameworks </t>
     <t>Know-how widely available  </t>
@@ -371,19 +375,26 @@ requires optimizing aspects such as:
 <section title="Profile of HTTP/2 for IoT"> 
   <t>HTTP/2 has many negotiable settings that can improve its performance for IoT applications by reducing bandwidth, codespace, and RAM requirements. Specifically, the following settings and values have been found to be useful in IoT applications:
     <list style='symbols'>
-      <t> SETTINGS_ENABLE_PUSH: This setting allows to enable/disable server push. This functionality may not be required in some IoT applications </t>
-      <t> SETTINGS_HEADER_TABLE_SIZE: this setting allows hosts to limit the size of the header compression table used for decoding, reducing required RAM, but potentially increasing bandwidth requirements </t>
-      <t> SETTINGS_INITIAL_WINDOW_SIZE: this setting allows hosts to limit the flow control window, potentially reducing buffer requirements at the expense of potentially underutilized bandwidth-delay products </t>
-      <t> SETTINGS_MAX_CONCURRENT_STREAMS: this settings allows hosts to limit the number of simultaneous streams for a connection </t>
-      <t> SETTINGS_MAX_FRAME_SIZE: this setting allows hosts to specify the largest frame size they are willing to receive. Somewhat counterintuitively, IoT hosts may wish to leave this value large and rely on flow control to avoid unnecessary framing overhead. </t>
-      <t> SETTINGS_MAX_HEADER_LIST_SIZE: this setting allows hosts to limit the maximum size of the header list they are willing to receive </t>
+      <t> SETTINGS_HEADER_TABLE_SIZE: this setting allows hosts to limit the size of the header compression table used for decoding, reducing required RAM, but potentially increasing bandwidth requirements. Initial value per HTTP/2 is 4096. IoT scenarios might benefit from changing this to a smaller value (e.g., 512), however, to avoid increased bandwidth usage, IoT scenarios should judiciously use HTTP headers and the dynamic header table <xref target="RFC7541"/>.  </t>
+      <t> SETTINGS_ENABLE_PUSH: This setting allows to enable/disable server push. This functionality may not be required in some IoT applications. The initial value per HTTP/2 is 1.</t>
+      <t> SETTINGS_MAX_CONCURRENT_STREAMS: this setting allows a sender to limit the number of simultaneous streams that a receiver can create for a connection. HTTP/2 recommends this value be no smaller than 100. IoS scenarios may wish to limit this to a much smaller number, such as 2 or 3. </t>
+      <t> SETTINGS_INITIAL_WINDOW_SIZE: this setting allows hosts to limit the flow control window, potentially reducing buffer requirements at the expense of potentially underutilized bandwidth-delay products. Per HTTP/2 the initial value is 2^16-1 (65,535) octets. IoT scenarios may wish to limit this to smaller values in accordance with the node's constraints (e.g., a few kilo-octets).
+ </t>
+      <t> SETTINGS_MAX_FRAME_SIZE: this setting allows hosts to specify the largest frame size they are willing to receive. Per HTTP/2 the initial value is 2^14 (16,384) octets. Somewhat counterintuitively, IoT hosts may wish to leave this value large and rely on flow control to avoid unnecessary framing overhead. </t>
+      <t> SETTINGS_MAX_HEADER_LIST_SIZE: this setting allows hosts to limit the maximum size of the header list they are willing to receive. Per HTTP/2 the initial value of this setting is unlimited. IoT scenarios may wish to limit this to smaller values in accordance with the node's constraints (e.g., a few kilo-octets).
+ </t>
     </list>
   </t>
 </section>
 
 <section title="Negotiation of HTTP/2 for IoT"> 
   <t>
-    TODO
+    For Internet scenarios, it is assumed that HTTP/2 runs over TLS. Accordingly, the ALPN negotiation in section 3.3 of <xref target="RFC7540"/> applies. As seen above, an IoT scenario may wish to depart from the default SETTINGS. To do so, the usual SETTINGS negotiation applies.
+	  In this case, the initial SETTINGS negotiation setup is based on the first message exchange initiated by the client.
+    This is simpler than general HTTP/2 case: not having an in-the-clear Upgrade path means the client is always in control of first HTTP/2 message, including any SETTINGS changes it may wish.
+  </t>
+  <t>
+    Additionally, the use of "prior knowledge" per section 3.4 of <xref target="RFC7540"/> is likely to also work particularly well in IoT scenarios in which a client and its web service are likely to be closely matched. In such scenarios, prior knowledge may allow for SETTINGS to be set in accordance with some shared state implied by the the prior knowledge. In such cases, SETTINGS negotiation may not be necessary in order to depart from the defaults as defined by HTTP/2.
   </t>
 </section>
 
@@ -588,6 +599,10 @@ date: Mon, 09 Mar 2015 06:26:44 GMT
    <t>QUIC also dictates that packets should be sized to fit within the path's MTU to avoid IP fragmentation. However path MTU discovery is work in
    progress, and the current QUIC implementation uses a 1350-byte maximum QUIC packet size for IPv6, 1370 for IPv4.</t>
 
+   <t>
+    Judging from its current state, QUIC may bring some potential benefits like the possibility to design and use a specific congestion control algorithm suited to IoT scenarios and possibility to reduce header overhead as compared to that of TCP plus HTTP/2. The latter is possible since these two layers are more integrated in QUIC.
+  </t> 
+
 </section>
 
     <section title="Acknowledgements">
@@ -601,12 +616,16 @@ date: Mon, 09 Mar 2015 06:26:44 GMT
   <back>
     <references title="Normative References">
       &RFC2119;
-      &RFC2616;
+
       &RFC7230;
       &RFC7231;
+      &RFC7540;
+      &RFC7541;
    </references>
 
    <references title="Informative References">
+      &RFC2616;
+      
       &RFC2629;
       
       <reference anchor="Deuterium" target="http://robbysimpson.org/deuterium/">

--- a/draft-montenegro-httpbis-h2ot.xml
+++ b/draft-montenegro-httpbis-h2ot.xml
@@ -68,39 +68,39 @@ This document makes the case for HTTP/2 for IoT.
   <middle>
     <section anchor="intro" title="Introduction">
 	<t>
-    When the IETF started work on IoT with the 6lowpan WG, it was clear that in addition to the lower-layer adaptation work 
+    When the IETF started work on the Internet-of-Things ("IoT") with the 6lowpan WG, it was clear that in addition to the lower-layer adaptation work 
     for IPv6, much work elsewhere in the stack was necessary. (In this
     document, the "things" in "IoT" are nodes that are constrained in some manner--e.g., cpu, memory, power--such that direct 
     use of unmodified mainstream protocols is challenging.) Once the IPv6 adaptation was understood, the next question 
-    was what protocols to use above IP for different functions and at different layers. 
+    was what protocols to use above IP(v6) for different functions and at different layers to have a complete stack. 
     That question may not have a single answer that is always best for all scenarios and use
-    cases. There are many such use cases, in accordance with the fact that "IoT" means too many things.     
+    cases. There are many such use cases, in accordance with the fact that IoT means too many things.     
 </t>
 
 <t> 
     Accordingly, the IoT landscape includes a proliferation of options for any particular functionality 
     (transport, encoding, security suites, authentication/authorization, etc). Different vendors and standards
     organizations (or fora) offer IoT solutions by grouping these different components into separate stacks.
-    Even if the components have the same name or originate in the same original standard (or even code base), each organization adapts it 
-    ever so slightly to their own goals rendering the resultant components non-interoperable. 
-    Many of these components are being created expressly for IoT (within the IETF and elsewhere) with the 
-    justification that the mainstream options could not possibly be usable for IoT scenarios, 
-    which results in multiple disparate networking and software stacks. Given the incipient state of IoT,
+    Even if the components have the same name or originate in the same original standard (or even in the same code base), 
+    each organization adapts it 
+    ever so slightly to their own goals, often rendering the resultant components non-interoperable. 
+    Many of these components are being created expressly for IoT (within the IETF and elsewhere) under the 
+    assumption that the mainstream options could not possibly be usable for IoT scenarios. 
+    This results in multiple disparate networking and software stacks. Given the incipient state of IoT,
     for the foreseeable future multiple competing stacks will continue to exist at least in gateways and 
     cloud elements.
-    This adds complexity to IoT,
-    hence, amplifying the attack surface. Nevertheless, properly configured and implemented, 
-    mainstream options may not just be workable, but may even be the best option. 
+    The additional complexity to IoT amplifies the attack surface. Nevertheless, properly configured and implemented, 
+    mainstream options may not just be workable, but may even be the best option at least in some scenarios. 
 </t>
 
 <t> 
     The appearance of one-off stacks (as opposed to a properly configured and adapted mainstream stack) is reminiscent of 
     WAP 1.x, a complete vertical stack offered for phones as they were starting to access the Internet (albeit from within 
     a walled garden) in the late 90's. At 
-    that time the IETF and the W3C started efforts to develop the mainstream alternatives. As a result, today no phone uses WAP. Phone 
-    stacks are mainstream TCP/IP protocols (properly configured and adapted, of course). In contrast, today in IoT 
-    we don't just see one non-mainstream
-    stack in IoT, but several (as if we had WAP1, WAP2, WAP3, etc.). And we may have to live with them for some time,
+    that time the IETF and the W3C started efforts to develop the mainstream alternatives. As a result, today no phone uses WAP. 
+    Instead, phone stacks are mainstream TCP/IP protocols (properly configured and adapted, of course). In contrast, today in IoT 
+    we see not just one non-mainstream
+    stack, but several (as if we had not just WAP, but WAP1, WAP2, WAP3, etc.). And we may have to live with them for some time,
     but it is essential to ponder what the mainstream stack might look like if we are to eventually reap the benefits of 
     a true Internet of Things instead of a not-quite-but-kinda-close-to-Internet-non-interoperable-hodge-podge-of-Things.
 </t>
@@ -150,8 +150,8 @@ This document makes the case for HTTP/2 for IoT.
 	</t>
   
 	<t>
-    This document makes the case for HTTP/2 as the most general protocol of choice for Internet of Things applications,
-    suitable for both Constrained network scenarios and Internet scenarios.
+    This document makes the case for HTTP/2 as the most general protocol of choice for Internet of Things applications.
+    HTTP/2 is most at home in Internet scenarios and is also suitable for at least some Constrained network scenarios.
 	</t>
 	</section>
 
@@ -183,7 +183,8 @@ This document makes the case for HTTP/2 for IoT.
 	</t>
   
   <t>
-    IT is interesting to note that in the same survey done in 2015, HTTP/2 was not even present, whereas it is now at 19%. No doubt
+    IT is interesting to note that in the same survey done in 2015, HTTP/2 was not even present, whereas it is now at 19% (the other protocols
+    are mostly unchanged). No doubt
     it is being used in scenarios where there are no major constraints (precisely where HTTP/1.x is also being used). Optimizing it for IoT
     can further promote its use. The sections below provide some more details on top-of-the-list protocols other than HTTP/2.
   </t>   
@@ -243,7 +244,7 @@ resource constrained devices and unreliable networks.
 
       <t>
       The protocol meets IoT requirements through the modification of some HTTP functionalities to achieve low-power consumption and operation over lossy links.
-      To avoid undesirable packet fragmentation the CoAP specification provides also an upper bound to the message size, dictating that a CoAP message,
+      To avoid undesirable packet fragmentation the CoAP specification provides an upper bound to the message size, dictating that a CoAP message,
       appropriately encapsulated, SHOULD fit within a single IP datagram
 
       <list style='hanging'>
@@ -255,12 +256,14 @@ resource constrained devices and unreliable networks.
    
 
  
-      In addition, CoAP may interact easily with HTTP through a proxy thanks to the common REST architecture. CoAP works on port 5683 and offers optional reliable 
-      delivery (thru a retransmission mechanism), support for unicast and multicast (which satisfies group communication for IoT), and asynchronous message exchange 
-      using simple and low complexity headers (a typical CoAP message can be between 10 and 20 bytes). 
+      CoAP interaction with HTTP must traverse a proxy, but at least the common REST architecture makes it easier. 
+      CoAP works on port 5683 and offers optional reliable 
+      delivery (thru a retransmission mechanism), support for unicast and multicast (which attempts to address group communication for IoT, but also 
+      introduces complexity for security, IPv6 scoping, wireless reliability, etc), and asynchronous message exchange 
+      A typical CoAP message can be between 10 and 20 bytes. 
       </t>
       <t>
-      It is the third most popular protocol in the survey with a 21% preference. Nevertheless, since CoAP is UDP-based, it also suffers from firewall traversal issues, verbosity (as compared to TCP) to maintain state in NAT boxes and lack of integration with existing enterprise infrastructures. There is ongoing work to specify the use of CoAP over TCP as well as CoAP over TLS, in an attempt to overcome issues with middleboxes and achieve a better integration with web environments.
+      It is the third most popular protocol in the survey with a 21% preference. Nevertheless, since CoAP is UDP-based, it also suffers from firewall traversal issues, verbosity (as compared to TCP) to maintain state in NAT boxes and lack of integration with existing enterprise infrastructures. There is ongoing work to specify the use of CoAP over TCP as well as CoAP over TLS, in an attempt to overcome issues with middleboxes and improve its applicability to Internet scenarios.
 		</t>
 
     </section>
@@ -272,7 +275,7 @@ resource constrained devices and unreliable networks.
      <t>Coexistence among the protocols has also been tested with varied network configurations. For the most part, interaction of CoAP with HTTP has been studied <xref target="Web_things"></xref>, demonstrating successful exchange when there is a CoAP server running on a constrained node and the HTTP client is requesting resources from it, or when there is a CoAP client requesting resources from an HTTP server. In both cases a proxy is necessary to enable translation between the protocols. Another network configuration with a CoAP client - CoAP proxy - CoAP server has been compared to the CoAP client - CoAP/HTTP proxy - HTTP server configuration, in which case the response times of the only-CoAP configuration resulted to be lower even when the number of concurrent requests increases <xref target="CoAP_integration"></xref>. </t>
      
      <t>
-     No reports have been found comparing MQTT or CoAP to HTTP/2.
+     To date, no reports have been found comparing MQTT or CoAP to HTTP/2.
     </t>
  </section>
    
@@ -614,7 +617,8 @@ date: Mon, 09 Mar 2015 06:26:44 GMT
         </front>
       </reference>
       
-      <reference anchor="Eclipse_survey">
+      <reference anchor="Eclipse_survey"
+        target="http://iot.ieee.org/images/files/pdf/iot-developer-survey-2016-report-final.pdf">
         <front>
           <title>IoT Developer Survey</title>
           <author>         
@@ -623,8 +627,8 @@ date: Mon, 09 Mar 2015 06:26:44 GMT
 		  </author>		
           <date month="April" year="2016" />
         </front>
-        </reference>
-        
+        </reference>      
+
        <reference anchor="IEEE_survey">
         <front>
           <title>Internet of Things: A Survey on Enabling Technologies, Protocols, and Applications</title>


### PR DESCRIPTION
Moved QUIC section to the end to have more continuity on http/2 for iot topics, editorial touches.
Added negotiation section, beefed up profile section and QUIC sections. 
Added HTTP/2 and HPACK references and moved RFC2616 to informative reference. 
More text on multicast (including how it is actually used by SDO's) and mDNS/DNS-SD. 
Added a bit more and references to the canonical stack section. 
